### PR TITLE
option to preserve the mean after rescaling

### DIFF
--- a/src/torch_fourier_rescale/fourier_rescale_2d.py
+++ b/src/torch_fourier_rescale/fourier_rescale_2d.py
@@ -67,7 +67,7 @@ def fourier_rescale_2d(
 
     # multiply with scale factor to ensure DC components remains the same
     if preserve_mean:
-        scale_factor = np.prod(rescaled_image.shape) / np.prod(image.shape)
+        scale_factor = np.prod(rescaled_image.shape[-2:]) / np.prod(image.shape[-2:])
         rescaled_image *= scale_factor
 
     return rescaled_image, tuple(new_spacing)

--- a/src/torch_fourier_rescale/fourier_rescale_2d.py
+++ b/src/torch_fourier_rescale/fourier_rescale_2d.py
@@ -13,6 +13,7 @@ def fourier_rescale_2d(
     image: torch.Tensor,
     source_spacing: float | tuple[float, float],
     target_spacing: float | tuple[float, float],
+    preserve_mean: bool = True,
 ) -> tuple[torch.Tensor, tuple[float, float]]:
     """Rescale 2D image(s) from `source_spacing` to `target_spacing`.
 
@@ -27,6 +28,8 @@ def fourier_rescale_2d(
         Pixel spacing in the input image.
     target_spacing: float | tuple[float, float]
         Pixel spacing in the output image.
+    preserve_mean: bool = True
+        Ensure that the mean (DC component) of the array is preserved after rescaling.
 
     Returns
     -------
@@ -49,7 +52,7 @@ def fourier_rescale_2d(
         dft=dft,
         image_shape=image.shape[-2:],
         source_spacing=source_spacing,
-        target_spacing=target_spacing
+        target_spacing=target_spacing,
     )
 
     # transform back to real space and recenter
@@ -61,6 +64,11 @@ def fourier_rescale_2d(
     source_spacing = np.array(source_spacing, dtype=np.float32)
     new_nyquist = np.array(new_nyquist, dtype=np.float32)
     new_spacing = 1 / (2 * new_nyquist * (1 / np.array(source_spacing)))
+
+    # multiply with scale factor to ensure DC components remains the same
+    if preserve_mean:
+        scale_factor = np.prod(rescaled_image.shape) / np.prod(image.shape)
+        rescaled_image *= scale_factor
 
     return rescaled_image, tuple(new_spacing)
 
@@ -104,21 +112,24 @@ def _fourier_crop_w(dft: torch.Tensor, image_width: int, target_fftfreq: float):
 def _fourier_pad_h(dft: torch.Tensor, image_height: int, target_fftfreq: float):
     delta_fftfreq = 1 / image_height
     idx_nyquist = target_fftfreq / delta_fftfreq
-    idx_nyquist = ceil(idx_nyquist) if ceil(idx_nyquist) % 2 == 0 else floor(idx_nyquist)
+    idx_nyquist = (
+        ceil(idx_nyquist) if ceil(idx_nyquist) % 2 == 0 else floor(idx_nyquist)
+    )
     new_nyquist = idx_nyquist * delta_fftfreq
     n_frequencies = (dft.shape[-2] // 2) + 1
     pad_h = idx_nyquist - (n_frequencies - 1)
-    dft = F.pad(dft, pad=(0, 0, pad_h, pad_h), mode='constant', value=0)
+    dft = F.pad(dft, pad=(0, 0, pad_h, pad_h), mode="constant", value=0)
     return dft, new_nyquist
 
 
 def _fourier_pad_w(dft: torch.Tensor, image_width: int, target_fftfreq: float):
     delta_fftfreq = 1 / image_width
     idx_nyquist = target_fftfreq / delta_fftfreq
-    idx_nyquist = ceil(idx_nyquist) if ceil(idx_nyquist) % 2 == 0 else floor(
-        idx_nyquist)
+    idx_nyquist = (
+        ceil(idx_nyquist) if ceil(idx_nyquist) % 2 == 0 else floor(idx_nyquist)
+    )
     new_nyquist = idx_nyquist * delta_fftfreq
     n_frequencies = dft.shape[-1]
     pad_w = idx_nyquist - (n_frequencies - 1)
-    dft = F.pad(dft, pad=(0, pad_w), mode='constant', value=0)
+    dft = F.pad(dft, pad=(0, pad_w), mode="constant", value=0)
     return dft, new_nyquist

--- a/src/torch_fourier_rescale/fourier_rescale_3d.py
+++ b/src/torch_fourier_rescale/fourier_rescale_3d.py
@@ -65,7 +65,7 @@ def fourier_rescale_3d(
 
     # multiply with scale factor to ensure DC components remains the same
     if preserve_mean:
-        scale_factor = np.prod(rescaled_image.shape) / np.prod(image.shape)
+        scale_factor = np.prod(rescaled_image.shape[-3:]) / np.prod(image.shape[-3:])
         rescaled_image *= scale_factor
 
     return rescaled_image, tuple(new_spacing)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,20 @@
 import einops
 import numpy as np
 import pytest
-
 import torch
 
 
 @pytest.fixture
 def circle():
-    coordinate_grid = einops.rearrange(np.indices((28, 28)), 'yx h w -> h w yx')
+    coordinate_grid = einops.rearrange(np.indices((28, 28)), "yx h w -> h w yx")
     coordinate_grid -= np.array([14, 14])
-    return torch.tensor(np.sum(coordinate_grid ** 2, axis=-1) ** 0.5) < 6
+    return (torch.tensor(np.sum(coordinate_grid**2, axis=-1) ** 0.5) < 6).float()
 
 
 @pytest.fixture
 def sphere():
-    coordinate_grid = einops.rearrange(np.indices((14, 14, 14)), 'zyx d h w -> d h w zyx')
+    coordinate_grid = einops.rearrange(
+        np.indices((14, 14, 14)), "zyx d h w -> d h w zyx"
+    )
     coordinate_grid -= np.array([7, 7, 7])
-    return torch.tensor(np.sum(coordinate_grid ** 2, axis=-1) ** 0.5) < 4
+    return (torch.tensor(np.sum(coordinate_grid**2, axis=-1) ** 0.5) < 4).float()

--- a/tests/test_torch_fourier_rescale.py
+++ b/tests/test_torch_fourier_rescale.py
@@ -7,7 +7,6 @@ def test_fourier_rescale_2d(circle):
     rescaled, new_spacing = fourier_rescale_2d(
         image=circle, source_spacing=1, target_spacing=0.5
     )
-    print(circle.mean())
     assert tuple(circle.shape) == (28, 28)
     assert tuple(rescaled.shape) == (56, 56)
     assert rescaled.mean() == pytest.approx(circle.mean())

--- a/tests/test_torch_fourier_rescale.py
+++ b/tests/test_torch_fourier_rescale.py
@@ -1,3 +1,5 @@
+import pytest
+
 from torch_fourier_rescale import fourier_rescale_2d, fourier_rescale_3d
 
 
@@ -5,8 +7,15 @@ def test_fourier_rescale_2d(circle):
     rescaled, new_spacing = fourier_rescale_2d(
         image=circle, source_spacing=1, target_spacing=0.5
     )
+    print(circle.mean())
     assert tuple(circle.shape) == (28, 28)
     assert tuple(rescaled.shape) == (56, 56)
+    assert rescaled.mean() == pytest.approx(circle.mean())
+
+    rescaled, new_spacing = fourier_rescale_2d(
+        image=circle, source_spacing=1, target_spacing=0.5, preserve_mean=False
+    )
+    assert rescaled.mean() != pytest.approx(circle.mean())
 
 
 def test_fourier_rescale_3d(sphere):
@@ -15,3 +24,9 @@ def test_fourier_rescale_3d(sphere):
     )
     assert tuple(sphere.shape) == (14, 14, 14)
     assert tuple(rescaled.shape) == (28, 28, 28)
+    assert rescaled.mean() == pytest.approx(sphere.mean())
+
+    rescaled, new_spacing = fourier_rescale_3d(
+        image=sphere, source_spacing=1, target_spacing=0.5, preserve_mean=False
+    )
+    assert rescaled.mean() != pytest.approx(sphere.mean())


### PR DESCRIPTION
Update 2d and 3d rescaling to preserve the DC component. Both have a keyword argument that activates this behavior that is true by default. I also expanded the tests to ensure this behavior is tested.