### PR TITLE
run preserve mean by modifying the fourier transform normalization

### DIFF
--- a/src/torch_fourier_rescale/fourier_rescale_2d.py
+++ b/src/torch_fourier_rescale/fourier_rescale_2d.py
@@ -58,10 +58,10 @@ def fourier_rescale_2d(
     # transform back to real space and recenter
     dft = torch.fft.ifftshift(dft, dim=(-2,))
     if preserve_mean:
-        rescaled_image = (  # norm='forward' deactivates default fft normalization
-            torch.fft.irfftn(dft, dim=(-2, -1), s=new_shape, norm="forward")
-            * (1 / np.prod(image.shape[-2:]))
-        )
+        # we changed the number of elements in the FT so set norm='forward' to deactivate
+        # default fft normalization by 1/n and normalise by the correct factor
+        rescaled_image = torch.fft.irfftn(dft, dim=(-2, -1), s=new_shape, norm="forward")
+        rescaled_image = rescaled_image * (1 / np.prod(image.shape[-2:]))
     else:
         rescaled_image = torch.fft.irfftn(dft, dim=(-2, -1), s=new_shape)
     rescaled_image = torch.fft.ifftshift(rescaled_image, dim=(-2, -1))

--- a/src/torch_fourier_rescale/fourier_rescale_2d.py
+++ b/src/torch_fourier_rescale/fourier_rescale_2d.py
@@ -57,18 +57,19 @@ def fourier_rescale_2d(
 
     # transform back to real space and recenter
     dft = torch.fft.ifftshift(dft, dim=(-2,))
-    rescaled_image = torch.fft.irfftn(dft, dim=(-2, -1), s=new_shape)
+    if preserve_mean:
+        rescaled_image = (  # norm='forward' deactivates default fft normalization
+            torch.fft.irfftn(dft, dim=(-2, -1), s=new_shape, norm="forward")
+            * (1 / np.prod(image.shape[-2:]))
+        )
+    else:
+        rescaled_image = torch.fft.irfftn(dft, dim=(-2, -1), s=new_shape)
     rescaled_image = torch.fft.ifftshift(rescaled_image, dim=(-2, -1))
 
     # Calculate new spacing after rescaling
     source_spacing = np.array(source_spacing, dtype=np.float32)
     new_nyquist = np.array(new_nyquist, dtype=np.float32)
     new_spacing = 1 / (2 * new_nyquist * (1 / np.array(source_spacing)))
-
-    # multiply with scale factor to ensure DC components remains the same
-    if preserve_mean:
-        scale_factor = np.prod(rescaled_image.shape[-2:]) / np.prod(image.shape[-2:])
-        rescaled_image *= scale_factor
 
     return rescaled_image, tuple(new_spacing)
 

--- a/src/torch_fourier_rescale/fourier_rescale_3d.py
+++ b/src/torch_fourier_rescale/fourier_rescale_3d.py
@@ -55,18 +55,19 @@ def fourier_rescale_3d(
 
     # transform back to real space and recenter
     dft = torch.fft.ifftshift(dft, dim=(-3, -2))
-    rescaled_image = torch.fft.irfftn(dft, dim=(-3, -2, -1), s=new_shape)
+    if preserve_mean:
+        rescaled_image = (  # norm='forward' deactivates default fft normalization
+            torch.fft.irfftn(dft, dim=(-3, -2, -1), s=new_shape, norm="forward")
+            * (1 / np.prod(image.shape[-3:]))
+        )
+    else:
+        rescaled_image = torch.fft.irfftn(dft, dim=(-3, -2, -1), s=new_shape)
     rescaled_image = torch.fft.ifftshift(rescaled_image, dim=(-3, -2, -1))
 
     # Calculate new spacing after rescaling
     source_spacing = np.array(source_spacing, dtype=np.float32)
     new_nyquist = np.array(new_nyquist, dtype=np.float32)
     new_spacing = 1 / (2 * new_nyquist * (1 / source_spacing))
-
-    # multiply with scale factor to ensure DC components remains the same
-    if preserve_mean:
-        scale_factor = np.prod(rescaled_image.shape[-3:]) / np.prod(image.shape[-3:])
-        rescaled_image *= scale_factor
 
     return rescaled_image, tuple(new_spacing)
 

--- a/src/torch_fourier_rescale/fourier_rescale_3d.py
+++ b/src/torch_fourier_rescale/fourier_rescale_3d.py
@@ -56,10 +56,10 @@ def fourier_rescale_3d(
     # transform back to real space and recenter
     dft = torch.fft.ifftshift(dft, dim=(-3, -2))
     if preserve_mean:
-        rescaled_image = (  # norm='forward' deactivates default fft normalization
-            torch.fft.irfftn(dft, dim=(-3, -2, -1), s=new_shape, norm="forward")
-            * (1 / np.prod(image.shape[-3:]))
-        )
+        # we changed the number of elements in the FT so set norm='forward' to deactivate
+        # default fft normalization by 1/n and normalise by the correct factor
+        rescaled_image = torch.fft.irfftn(dft, dim=(-3, -2, -1), s=new_shape, norm="forward")
+        rescaled_image = rescaled_image * (1 / np.prod(image.shape[-3:]))
     else:
         rescaled_image = torch.fft.irfftn(dft, dim=(-3, -2, -1), s=new_shape)
     rescaled_image = torch.fft.ifftshift(rescaled_image, dim=(-3, -2, -1))


### PR DESCRIPTION
Closes #13 

Solution as mentioned in the issue. Setting norm='forward' in irfftn turns it off in the inverse transform as it expects it to happen in the rfftn, that lets us set the normalization ourselves.